### PR TITLE
Release/v0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impostr",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Impostr helps you keep track of who's who and what's what. Simple caching tool for checking for file changes over time.",
   "main": "build/impostr.js",
   "repository": "https://github.com/cgatno/impostr",

--- a/src/lib/TrackingCache.js
+++ b/src/lib/TrackingCache.js
@@ -73,7 +73,7 @@ export default class TrackingCache {
    */
   trackFiles(globPattern, done) {
     if (this.debug) console.log(`Tracking files matching pattern ${globPattern}...`);
-    glob(globPattern, { nodir: true }, (err, files) => {
+    glob(globPattern, { nodir: true, symlinks: true }, (err, files) => {
       if (err) {
         if (this.debug) console.log('IMPOSTR ERROR: ', JSON.stringify(err));
         throw err;


### PR DESCRIPTION
**Changelog**

- Impostr will now follow all symlinks when creating a cache

_Breaking Changes_

If you were caching paths with symlinks in them before, note that they'll also be cached now. You can manually exclude them with the glob pattern if you want to leave them out.